### PR TITLE
Fallback to calculate energy if it's not available directly

### DIFF
--- a/main.py
+++ b/main.py
@@ -265,7 +265,7 @@ def plot(cur: sqlite3.Cursor, args: argparse.Namespace) -> None:
 
     plt.title(', '.join(title))
     ax.set_xlabel('duration (h)')
-    ax.set_ylabel('energy (Wh)')
+    ax.set_ylabel('energy (W)')
     (handles, labels) = ax.get_legend_handles_labels()
     handles.extend([
         mpatches.Patch(color='grey', label=f'est. duration (days): {est_duration_d:.1f}'),


### PR DESCRIPTION
On some laptops the `energy_now` and `energy_full` files don't exist, but the `charge_now` and `charge_full` files exist instead, and with `voltage_min_design` you can calculate the energy yourself.

For laptops where the `energy_*` files exist, everything still works the same as before, but if not, it tries to fallback to the `charge_*` files if available, before failing.

Also fix the y-axis label to show "W" instead of "Wh".